### PR TITLE
adding test repo for auto-shutdown skip testing

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -15,6 +15,8 @@
     - 'repo:hmcts/aks-auto-shutdown:pull_request'
     - 'repo:hmcts/aks-auto-shutdown-1:ref:refs/heads/master'
     - 'repo:hmcts/aks-auto-shutdown-1:pull_request'
+    - 'repo:hmcts/aks-auto-shutdown-releases:ref:refs/heads/master'
+    - 'repo:hmcts/aks-auto-shutdown-releases:pull_request'
   permissions: []
 - name: Sandbox Cleanup
   subjects:


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-13971


### Change description ###
Adding test repo aks-auto-shutdown-releases to enable end to end testing of skip shutdown functionality.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
