### PR TITLE
Harden GitHub action OIDC with enterprise issuer

### DIFF
--- a/modules/azure-github-federation/main.tf
+++ b/modules/azure-github-federation/main.tf
@@ -43,6 +43,6 @@ resource "azuread_application_federated_identity_credential" "this" {
   application_object_id = azuread_application.this[each.value.app].object_id
   display_name          = replace(replace(each.value.subject, "/", "__"), ":", "_") // API is not accepting ":" or "/" replacing with "_" and "__"
   audiences             = ["api://AzureADTokenExchange"]
-  issuer                = "https://token.actions.githubusercontent.com"
+  issuer                = "https://token.actions.githubusercontent.com/hmcts"
   subject               = each.value.subject
 }


### PR DESCRIPTION
see https://securitylabs.datadoghq.com/articles/exploring-github-to-aws-keyless-authentication-flaws/

https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise