### PR TITLE
Add orphaned resource cleanup application with scope of CFT sandbox

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -68,3 +68,11 @@
       scopes:
         - /subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb
         - /subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/finops-reporting-sbox-rg
+- name: DTS Orphaned Resource Cleanup
+  subjects:
+    - 'repo:hmcts/dtspo-orphan-resources-cleanup/tree/master'
+    - 'repo:hmcts/dtspo-orphan-resources-cleanup/tree/dxw/orphan-testing'
+  permissions:
+    - role_definition_name: Orphan Resource Cleanup Read/Delete
+      scopes:
+        - /providers/Microsoft.Management/managementGroups/CFT-Sandbox


### PR DESCRIPTION
### JIRA link (if applicable) ###

- https://tools.hmcts.net/jira/browse/DTSPO-13983


### Change description ###

* Add DTSPO Orphaned Resource Cleanup application/service principal with scope limited to CFT sandbox management group and for use only by https://github.com/hmcts/dtspo-orphan-resources-cleanup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
