### PR TITLE
Add Non-Prod management group scope to DTS Orphaned Resource Cleanup

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -76,3 +76,4 @@
     - role_definition_name: Orphan Resource Cleanup Read/Delete
       scopes:
         - /providers/Microsoft.Management/managementGroups/CFT-Sandbox
+        - /providers/Microsoft.Management/managementGroups/CFT - Non-production


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-13983


### Change description ###

* Add Non-Prod management group scope to DTS Orphaned Resource Cleanup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
