### PR TITLE
DTSPO-16389: remove keyvault roles as access policy only

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -98,6 +98,3 @@
         - /providers/Microsoft.Management/managementGroups/Heritage-Sandbox
         - /providers/Microsoft.Management/managementGroups/Heritage-NonProd
         - /providers/Microsoft.Management/managementGroups/Heritage-Prod
-    - role_definition_name: Key Vault Secrets User
-      scopes:
-        - /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.KeyVault/vaults/cftptl-intsvc


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16389


### Change description ###

- remove keyvault role assignment as access policy only


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
