### PR TITLE
DTSPO-17194 - adding dev enviornment, removing legacy shutdown-1 repo

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -13,13 +13,12 @@
   subjects:
     - 'repo:hmcts/auto-shutdown:ref:refs/heads/master'
     - 'repo:hmcts/auto-shutdown:pull_request'
-    - 'repo:hmcts/aks-auto-shutdown-1:ref:refs/heads/master'
-    - 'repo:hmcts/aks-auto-shutdown-1:pull_request'
+    - 'repo:hmcts/auto-shutdown-dev:ref:refs/heads/master'
+    - 'repo:hmcts/auto-shutdown-dev:pull_request'
     - 'repo:hmcts/aks-auto-shutdown-releases:ref:refs/heads/master'
     - 'repo:hmcts/aks-auto-shutdown-releases:pull_request'
     - 'repo:hmcts/DTSPO-17195_auto-shutdown:ref:refs/heads/master'
     - 'repo:hmcts/DTSPO-17195_auto-shutdown:pull_request'
-    - 'repo:hmcts/aks-auto-shutdown-releases:ref:refs/heads/jh-shutdown-1'
   permissions:
     - role_definition_name: 'Contributor'
       scopes:


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-17194


### Change description ###
Adding "official" dev environment with appropriate name & now a fork of main / prod auto shutdown repo.
aks-auto-shutdown-releases to be deleted once current development work is complete.
