### PR TITLE
Adding Recipe Receiver federated app reg to use for github workflows

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -55,7 +55,7 @@
         - /subscriptions/ea3a8c1e-af9d-4108-bc86-a7e2d267f49c
         - /subscriptions/cdc31e8e-43f4-4c8a-8b50-635e954c27d3
         - /subscriptions/1fe7db01-9981-4ed3-983c-163dd50ba43a
-        - /subscriptions/5709598c-3a1c-4535-8979-f10948b9a031   
+        - /subscriptions/5709598c-3a1c-4535-8979-f10948b9a031
 - name: DTS AKS Application Testing
   subjects:
     - 'repo:hmcts/sds-flux-config:ref:refs/heads/master'
@@ -111,3 +111,14 @@
     - 'repo:hmcts/hmcts.github.io:pull_request'
     - 'repo:hmcts/hmcts.github.io:environment:github-pages'
   permissions: []
+- name: DTS Recipe Receiver testing
+  subjects:
+    - 'repo:hmcts/recipe-receiver:ref:refs/heads/master'
+    - 'repo:hmcts/recipe-receiver:ref:pull_request'
+  permissions:
+    - role_definition_name: Reader
+      scopes:
+        - /providers/Microsoft.Management/managementGroups/CFT-Sandbox
+        - /providers/Microsoft.Management/managementGroups/CFT-NonProd
+        - /providers/Microsoft.Management/managementGroups/SDS-Sandbox
+        - /providers/Microsoft.Management/managementGroups/SDS-NonProd


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-18467

### Change description
Adding a new app registration for recipe receiver workflows
Giving reader access to non-prod subscriptions only
