### PR TITLE
prod repos required for container registry access

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -117,5 +117,7 @@
       scopes:
         - /providers/Microsoft.Management/managementGroups/CFT-Sandbox
         - /providers/Microsoft.Management/managementGroups/CFT-NonProd
+        - /providers/Microsoft.Management/managementGroups/CFT-Prod
         - /providers/Microsoft.Management/managementGroups/SDS-Sandbox
         - /providers/Microsoft.Management/managementGroups/SDS-NonProd
+        - /providers/Microsoft.Management/managementGroups/SDS-Prod


### PR DESCRIPTION
DTS Recipe Receiver requires read on prod to access container registries.