### PR TITLE
DTSPO-30331: add acr-base-importer fed cred for non-oci helm chart import GH action

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -173,6 +173,24 @@
 ## Please check the readme in this folder before making any changes to these as there
 ## are known limitations
 ########################################################################################
+- name: DTS Platform Operations GitHub Actions ACR Publisher 2
+  subjects:
+    - 'repo:hmcts/acr-base-importer:ref:refs/heads/master'
+    - 'repo:hmcts/acr-base-importer:pull_request'
+  permissions:
+    - role_definition_name: 'AcrPush'
+      scopes:
+        - /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/rpe-acr-prod-rg # DCD-CNP-Prod
+        - /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cnp-acr-rg # DCD-CFT-Sandbox
+    - role_definition_name: 'AcrPull'
+      scopes:
+        - /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/rpe-acr-prod-rg # DCD-CNP-Prod
+        - /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cnp-acr-rg # DCD-CFT-Sandbox
+########################################################################################
+## The below App Registrations have been created for use in GitHub Actions workflows
+## Please check the readme in this folder before making any changes to these as there
+## are known limitations
+########################################################################################
 - name: DTS Shared GitHub Actions ACR Publisher 1
   subjects:
     - 'repo:hmcts/mssql-backup-converter:ref:refs/heads/main'


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30331

### Change description

- Add second PlatOps app reg (max 20 subjects per)
- Add acr-base-importer fed cred for push/pull from ACRs
- To be used for scheduled github action in acr-base-importer to mirror non-oci helm charts to ACR

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
