### PR TITLE
Add cft-workspace ACR publishing access

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -178,6 +178,8 @@
     - 'repo:hmcts/acr-base-importer:pull_request'
     - 'repo:hmcts/hmcts-kubectl:ref:refs/heads/master'
     - 'repo:hmcts/hmcts-kubectl:pull_request'
+    - 'repo:hmcts/cft-workspace:ref:refs/heads/master'
+    - 'repo:hmcts/cft-workspace:pull_request'
   permissions:
     - role_definition_name: 'AcrPush'
       scopes:


### PR DESCRIPTION
Adds `hmcts/cft-workspace` (master + pull_request subjects) to the **DTS Platform Operations GitHub Actions ACR Publisher 2** app registration so its `publish-devcontainer.yml` workflow can push images to `hmctspublic.azurecr.io` via OIDC.

Publisher 2 currently has 4 subjects; this brings it to 6, well under the 20-credential cap. Publisher 1 is full.

Pairs with hmcts/central-app-registration PR adding `cft-workspace-repo`.