### PR TITLE
Add dtsse config generator ACR environment subject

### DIFF
--- a/app-registrations.yaml
+++ b/app-registrations.yaml
@@ -316,6 +316,7 @@
     - 'repo:hmcts/rse-cft-lib:pull_request'
     - 'repo:hmcts/dtsse-ccd-config-generator:ref:refs/heads/master'
     - 'repo:hmcts/dtsse-ccd-config-generator:pull_request'
+    - 'repo:hmcts/dtsse-ccd-config-generator:environment:cftlib-acr-pull'
     - 'repo:hmcts/amc-CaseMan:ref:refs/heads/master'
     - 'repo:hmcts/amc-CaseMan:pull_request'
   permissions:


### PR DESCRIPTION
Adds a GitHub environment OIDC subject for hmcts/dtsse-ccd-config-generator so ACR login can work from merge queue workflow runs as well as pull request runs.